### PR TITLE
Updated code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ plugins: [
     options: {
       plugins: [
         {
-          resolve: `gatsby-remark-oembed`,
+          resolve: `@raae/gatsby-remark-oembed`,
           options: {
             providers: {
               // Important to exclude providers


### PR DESCRIPTION
I just tried out your plugin and it's pretty awesome. However, to get it working, I had to prefix the plugin with your scoped package name. Just updating the read me as I imagine others will run into the same issue.

```
error Unable to find plugin "gatsby-remark-oembed". Perhaps you need to install its package?


  Error: Unable to find plugin "gatsby-remark-oembed". Perhaps you need to install its package?
```