### PR TITLE
Adds examples of oembed parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,34 @@ plugins: [
       ]
     }
   }
-]
+];
+```
+
+#### Optional `settings` for providers
+
+Many oEmbed providers offer additional options for configure the display of the embed.
+
+For example, for Instagram see [Instagram – Embedding for Developers](https://www.instagram.com/developer/embedding/), which describes the additional oEmbed parameters you might want to change for the embed.
+
+```js
+// …
+{
+  resolve: `@raae/gatsby-remark-oembed`,
+  options: {
+    providers: {
+      include: [
+        'Twitter',
+        'Instagram',
+      ]
+      settings: {
+        // Ex. Show all Twitter embeds with the dark theme
+        Twitter: { theme: 'dark' },
+        // Ex. Hide all Instagram comments by default
+        Instagram: { showcomments: false },
+      },
+    },
+  },
+}
 ```
 
 ### Content

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Check out [gatsby-remark-oembed.netlify.com/](https://gatsby-remark-oembed.netli
 
 ### Configuration
 
-```
+```js
 // In your gatsby-config.js
 plugins: [
   {

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ Links must be surrounded by empty lines.
 
 ## Options
 
-| Name                | Type                   | Description                                                 |
-| ------------------- | ---------------------- | ----------------------------------------------------------- |
-| `providers.include` | Array of provider keys | Only links from providers on this list will be transformed. |
-| `providers.exclude` | Array of provider keys | Links from providers on this list will not be transformed.  |
+| Name                 | Type                        | Description                                                 |
+| -------------------- | --------------------------- | ----------------------------------------------------------- |
+| `providers.include`  | Array of provider keys      | Only links from providers on this list will be transformed. |
+| `providers.exclude`  | Array of provider keys      | Links from providers on this list will not be transformed.  |
+| `providers.settings` | Object of provider settings | Optional configuration unique to each provider.             |
 
 ## Buy med a coffee? 
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, for Instagram see [Instagram – Embedding for Developers](https://
         // Ex. Show all Twitter embeds with the dark theme
         Twitter: { theme: 'dark' },
         // Ex. Hide all Instagram comments by default
-        Instagram: { showcomments: false },
+        Instagram: { hidecaption: false },
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example, for Instagram see [Instagram – Embedding for Developers](https://
         // Ex. Show all Twitter embeds with the dark theme
         Twitter: { theme: 'dark' },
         // Ex. Hide all Instagram comments by default
-        Instagram: { hidecaption: false },
+        Instagram: { hidecaption: true },
       },
     },
   },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,11 +8,11 @@ const {
 exports.onPreBootstrap = async ({ cache }, rawOptions) => {
   const options = ammendOptions(rawOptions);
   const rawProviders = await fetchOembedProviders();
-  const providers = processProviders(rawProviders, options);
+  const providers = processProviders(rawProviders, options, rawOptions);
   await cache.set("remark-oembed-providers", providers);
 };
 
-const processProviders = (providers, options) => {
-  providers = ammendProviders(providers);
-  return filterProviders(providers, options.providers);
+const processProviders = (providers, optionsAsStrings, rawOptions) => {
+  providers = ammendProviders(providers, rawOptions);
+  return filterProviders(providers, optionsAsStrings.providers);
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,11 +8,11 @@ const {
 exports.onPreBootstrap = async ({ cache }, rawOptions) => {
   const options = ammendOptions(rawOptions);
   const rawProviders = await fetchOembedProviders();
-  const providers = processProviders(rawProviders, options, rawOptions);
+  const providers = processProviders(rawProviders, options.providers);
   await cache.set("remark-oembed-providers", providers);
 };
 
-const processProviders = (providers, optionsAsStrings, rawOptions) => {
-  providers = ammendProviders(providers, rawOptions);
-  return filterProviders(providers, optionsAsStrings.providers);
+const processProviders = (providers, providerOptions = {}) => {
+  providers = ammendProviders(providers, providerOptions.settings);
+  return filterProviders(providers, providerOptions);
 };

--- a/helper.test.data.js
+++ b/helper.test.data.js
@@ -1,0 +1,225 @@
+exports.MARKDOWN_AST = {
+  children: [
+    {
+      position: {
+        end: {
+          column: 4,
+          line: 4,
+          offset: 62
+        },
+        indent: [1, 1, 1],
+        start: {
+          column: 1,
+          line: 1,
+          offset: 0
+        }
+      },
+      type: "yaml",
+      value: 'title: New Beginnings\ndate: "2015-05-28T22:40:32.169Z"'
+    },
+    {
+      children: [
+        {
+          children: [
+            {
+              position: {
+                end: {
+                  column: 44,
+                  line: 6,
+                  offset: 107
+                },
+                indent: [],
+                start: {
+                  column: 1,
+                  line: 6,
+                  offset: 64
+                }
+              },
+              type: "text",
+              value: "https://www.youtube.com/watch?v=b2H7fWhQcdE"
+            }
+          ],
+          position: {
+            end: {
+              column: 44,
+              line: 6,
+              offset: 107
+            },
+            indent: [],
+            start: {
+              column: 1,
+              line: 6,
+              offset: 64
+            }
+          },
+          title: null,
+          type: "link",
+          url: "https://www.youtube.com/watch?v=b2H7fWhQcdE"
+        }
+      ],
+      position: {
+        end: {
+          column: 44,
+          line: 6,
+          offset: 107
+        },
+        indent: [],
+        start: {
+          column: 1,
+          line: 6,
+          offset: 64
+        }
+      },
+      type: "paragraph"
+    },
+    {
+      children: [
+        {
+          position: {
+            end: {
+              column: 29,
+              line: 9,
+              offset: 213
+            },
+            indent: [1],
+            start: {
+              column: 1,
+              line: 8,
+              offset: 109
+            }
+          },
+          type: "text",
+          value:
+            "Far far away, behind the word mountains, far from the countries Vokalia and\nConsonantia, there live the "
+        },
+        {
+          children: [
+            {
+              position: {
+                end: {
+                  column: 41,
+                  line: 9,
+                  offset: 225
+                },
+                indent: [],
+                start: {
+                  column: 30,
+                  line: 9,
+                  offset: 214
+                }
+              },
+              type: "text",
+              value: "blind texts"
+            }
+          ],
+          position: {
+            end: {
+              column: 62,
+              line: 9,
+              offset: 246
+            },
+            indent: [],
+            start: {
+              column: 29,
+              line: 9,
+              offset: 213
+            }
+          },
+          title: null,
+          type: "link",
+          url: "http://example.com"
+        },
+        {
+          position: {
+            end: {
+              column: 102,
+              line: 9,
+              offset: 286
+            },
+            indent: [],
+            start: {
+              column: 62,
+              line: 9,
+              offset: 246
+            }
+          },
+          type: "text",
+          value: ". Separated they live in Bookmarksgrove."
+        }
+      ],
+      position: {
+        end: {
+          column: 102,
+          line: 9,
+          offset: 286
+        },
+        indent: [1],
+        start: {
+          column: 1,
+          line: 8,
+          offset: 109
+        }
+      },
+      type: "paragraph"
+    }
+  ],
+  position: {
+    end: {
+      column: 1,
+      line: 10,
+      offset: 287
+    },
+    start: {
+      column: 1,
+      line: 1,
+      offset: 0
+    }
+  },
+  type: "root"
+};
+
+exports.PROVIDERS = [
+  {
+    provider_name: "Instagram",
+    provider_url: "https://instagram.com",
+    endpoints: [
+      {
+        schemes: [
+          "http://instagram.com/p/*",
+          "http://instagr.am/p/*",
+          "http://www.instagram.com/p/*",
+          "http://www.instagr.am/p/*",
+          "https://instagram.com/p/*",
+          "https://instagr.am/p/*",
+          "https://www.instagram.com/p/*",
+          "https://www.instagr.am/p/*"
+        ],
+        url: "https://api.instagram.com/oembed",
+        formats: ["json"]
+      }
+    ]
+  },
+  {
+    provider_name: "Kickstarter",
+    provider_url: "http://www.kickstarter.com",
+    endpoints: [
+      {
+        schemes: ["http://www.kickstarter.com/projects/*"],
+        url: "http://www.kickstarter.com/services/oembed"
+      }
+    ]
+  },
+  {
+    provider_name: "Twitter",
+    provider_url: "http://www.twitter.com/",
+    endpoints: [
+      {
+        schemes: [
+          "https://twitter.com/*/status/*",
+          "https://*.twitter.com/*/status/*"
+        ],
+        url: "https://publish.twitter.com/oembed"
+      }
+    ]
+  }
+];

--- a/helper.test.js
+++ b/helper.test.js
@@ -36,7 +36,7 @@ describe("#filterProviders", () => {
   const instagram = {
     provider_name: "Instagram"
   };
-
+  
   const providers = [kickstarter, twitter, instagram];
 
   test("do nothing to the list of providers", () => {
@@ -75,6 +75,37 @@ describe("#filterProviders", () => {
     expect(filteredProviders).toEqual(
       expect.arrayContaining([kickstarter]),
       expect.not.arrayContaining([instagram, twitter])
+    );
+  });
+  
+  test("returns a list with Instagram, from extra provider config", () => {
+    const filteredProviders = filterProviders(providers, {
+      include: [{
+        name: 'Instagram',
+        hidecaption: true,
+        omitscript: true
+      }]
+    });
+
+    expect(filteredProviders).toEqual(
+      expect.arrayContaining([instagram]),
+      expect.not.arrayContaining([twitter, kickstarter])
+    );
+  });
+  
+  test("returns a list with Twitter and Instagram, from extra and regular config", () => {
+    const filteredProviders = filterProviders(providers, {
+      include: [{
+        name: 'Instagram',
+        hidecaption: true,
+        omitscript: true
+      },
+      'Twitter']
+    });
+
+    expect(filteredProviders).toEqual(
+      expect.arrayContaining([instagram, twitter]),
+      expect.not.arrayContaining([kickstarter])
     );
   });
 });

--- a/helper.test.js
+++ b/helper.test.js
@@ -78,36 +78,39 @@ describe("#filterProviders", () => {
     );
   });
   
-  test("returns a list with Instagram, from extra provider config", () => {
-    const filteredProviders = filterProviders(providers, {
-      include: [{
-        name: 'Instagram',
-        hidecaption: true,
-        omitscript: true
-      }]
-    });
-
-    expect(filteredProviders).toEqual(
-      expect.arrayContaining([instagram]),
-      expect.not.arrayContaining([twitter, kickstarter])
-    );
-  });
-  
-  test("returns a list with Twitter and Instagram, from extra and regular config", () => {
-    const filteredProviders = filterProviders(providers, {
-      include: [{
-        name: 'Instagram',
-        hidecaption: true,
-        omitscript: true
-      },
-      'Twitter']
-    });
-
-    expect(filteredProviders).toEqual(
-      expect.arrayContaining([instagram, twitter]),
-      expect.not.arrayContaining([kickstarter])
-    );
-  });
+  // This gets converted before it gets to filterProviders
+  // test("returns a list with Instagram, from extra provider config", () => {
+  //   const filteredProviders = filterProviders(providers, {
+  //     include: [{
+  //       name: 'Instagram',
+  //       hidecaption: true,
+  //       omitscript: true
+  //     }]
+  //   });
+  // 
+  //   expect(filteredProviders).toEqual(
+  //     expect.arrayContaining([instagram]),
+  //     expect.not.arrayContaining([twitter, kickstarter])
+  //   );
+  // });
+  // 
+  // test("returns a list with Twitter and Instagram, from extra and regular config", () => {
+  //   const filteredProviders = filterProviders(providers, {
+  //     include: [
+  //       {
+  //         name: 'Instagram',
+  //         hidecaption: true,
+  //         omitscript: true
+  //       },
+  //       'Twitter'
+  //     ]
+  //   });
+  // 
+  //   expect(filteredProviders).toEqual(
+  //     expect.arrayContaining([instagram, twitter]),
+  //     expect.not.arrayContaining([kickstarter])
+  //   );
+  // });
 });
 
 describe("#filterProviderKeys", () => {

--- a/helper.test.js
+++ b/helper.test.js
@@ -5,7 +5,9 @@ const {
   selectPossibleOembedLinkNodes,
   tranformsLinkNodeToOembedNode,
   filterProviders,
-  filterProviderKeys
+  filterProviderKeys,
+  ammendOptions,
+  ammendProviders,
 } = require("./helpers");
 
 describe("#fetchOembedProviders", () => {
@@ -77,40 +79,51 @@ describe("#filterProviders", () => {
       expect.not.arrayContaining([instagram, twitter])
     );
   });
+});
+
+// This tests the verbose config you’d write in gatsby-node.js,
+// and whether it is correctly formatted into an array of
+// strings to be used in the existing functions,
+// like filterProviders
+describe("#ammendProviders", () => {
+  test("returns a list with Instagram, from extra provider config", () => {
+    let expectedResult = [{"endpoints": [{"formats": ["json"], "params": {}, "schemes": ["http://instagram.com/p/*", "http://instagr.am/p/*", "http://www.instagram.com/p/*", "http://www.instagr.am/p/*", "https://instagram.com/p/*", "https://instagr.am/p/*", "https://www.instagram.com/p/*", "https://www.instagr.am/p/*"], "url": "https://api.instagram.com/oembed"}], "params": {"hidecaption": true, "name": "Instagram", "omitscript": true}, "provider_name": "Instagram", "provider_url": "https://instagram.com"}, {"endpoints": [{"params": {}, "schemes": ["http://www.kickstarter.com/projects/*"], "url": "http://www.kickstarter.com/services/oembed"}], "provider_name": "Kickstarter", "provider_url": "http://www.kickstarter.com"}, {"endpoints": [{"params": {}, "schemes": ["https://twitter.com/*/status/*", "https://*.twitter.com/*/status/*"],"url": "https://publish.twitter.com/oembed"}], "provider_name": "Twitter", "provider_url": "http://www.twitter.com/"}]
+    let verboseInstagramConfig = {
+      name: 'Instagram',
+      hidecaption: true,
+      omitscript: true
+    }
+
+    const result = ammendProviders(providers, {
+      include: [verboseInstagramConfig]
+    });
+    
+    console.log(result[0].provider_name, result[1].endpoints.params)
+    expect(result).toEqual(
+      expect.arrayContaining(expectedResult),
+    );
+  });
   
-  // This gets converted before it gets to filterProviders
-  // test("returns a list with Instagram, from extra provider config", () => {
-  //   const filteredProviders = filterProviders(providers, {
-  //     include: [{
-  //       name: 'Instagram',
-  //       hidecaption: true,
-  //       omitscript: true
-  //     }]
-  //   });
-  // 
-  //   expect(filteredProviders).toEqual(
-  //     expect.arrayContaining([instagram]),
-  //     expect.not.arrayContaining([twitter, kickstarter])
-  //   );
-  // });
-  // 
-  // test("returns a list with Twitter and Instagram, from extra and regular config", () => {
-  //   const filteredProviders = filterProviders(providers, {
-  //     include: [
-  //       {
-  //         name: 'Instagram',
-  //         hidecaption: true,
-  //         omitscript: true
-  //       },
-  //       'Twitter'
-  //     ]
-  //   });
-  // 
-  //   expect(filteredProviders).toEqual(
-  //     expect.arrayContaining([instagram, twitter]),
-  //     expect.not.arrayContaining([kickstarter])
-  //   );
-  // });
+  test("returns a list with Twitter and Instagram, from extra and regular config", () => {
+    let expectedResult = [{"endpoints": [{"formats": ["json"], "params": {}, "schemes": ["http://instagram.com/p/*", "http://instagr.am/p/*", "http://www.instagram.com/p/*", "http://www.instagr.am/p/*", "https://instagram.com/p/*", "https://instagr.am/p/*", "https://www.instagram.com/p/*", "https://www.instagr.am/p/*"], "url": "https://api.instagram.com/oembed"}], "params": {"hidecaption": true, "name": "Instagram", "omitscript": true}, "provider_name": "Instagram", "provider_url": "https://instagram.com"}, {"endpoints": [{"params": {}, "schemes": ["http://www.kickstarter.com/projects/*"], "url": "http://www.kickstarter.com/services/oembed"}], "provider_name": "Kickstarter", "provider_url": "http://www.kickstarter.com"}, {"endpoints": [{"params": {}, "schemes": ["https://twitter.com/*/status/*", "https://*.twitter.com/*/status/*"],"url": "https://publish.twitter.com/oembed"}], "provider_name": "Twitter", "provider_url": "http://www.twitter.com/"}]
+    let verboseInstagramConfig = {
+      name: 'Instagram',
+      hidecaption: true,
+      omitscript: true
+    }
+
+    const result = ammendProviders(providers, {
+      include: [verboseInstagramConfig, 'Twitter']
+    });
+  
+    console.log(result[0].provider_name, result[1].endpoints.params)
+    expect(result).toEqual(
+      expect.arrayContaining(expectedResult),
+    );
+  
+  });
+});
+
 });
 
 describe("#filterProviderKeys", () => {

--- a/helper.test.js
+++ b/helper.test.js
@@ -170,7 +170,7 @@ describe("#getProviderEndpointUrlForLinkUrl", () => {
         "https://www.instagram.com/p/BftIg_OFPFX/",
         providers
       )
-    ).toBe("https://api.instagram.com/oembed");
+    ).toEqual({ url: "https://api.instagram.com/oembed", params: {} });
   });
 });
 
@@ -182,7 +182,7 @@ describe("#fetchOembed", () => {
     return expect(
       fetchOembed(
         "https://www.instagram.com/p/BftIg_OFPFX/",
-        "https://api.instagram.com/oembed"
+        { url: "https://api.instagram.com/oembed", params: {} }
       )
     ).resolves.toMatchObject(response);
   });

--- a/helper.test.js
+++ b/helper.test.js
@@ -124,6 +124,57 @@ describe("#ammendProviders", () => {
   });
 });
 
+describe("#ammendOptions", () => {
+  test("returns plain provider config unchanged", () => {
+    let result = ammendOptions({
+      providers: {
+        include: ['Twitter'],
+        exclude: ['Instagram']
+      }
+    })
+    
+    expect(result).toEqual({
+      providers: {
+        include: ['Twitter'],
+        exclude: ['Instagram']
+      }
+    })
+  })
+  
+  test("returns extended provider config as array of strings", () => {
+    let result = ammendOptions({
+      providers: {
+        include: [{ name: 'Twitter', darkTheme: true }],
+        exclude: [{ name: 'Instagram', showComments: false }]
+      }
+    })
+    
+    expect(result).toEqual({
+      providers: {
+        include: ['Twitter'],
+        exclude: ['Instagram']
+      }
+    })
+  })
+  
+  test("returns mixed provider config as array of strings", () => {
+    let result = ammendOptions({
+      providers: {
+        include: [
+          'Kickstarter',
+          'Instagram',
+          { name: 'Twitter', darkTheme: true }
+        ],
+      }
+    })
+    
+    expect(result).toEqual({
+      providers: {
+        include: ['Kickstarter', 'Instagram', 'Twitter'],
+        exclude: undefined
+      }
+    })
+  })
 });
 
 describe("#filterProviderKeys", () => {

--- a/helper.test.js
+++ b/helper.test.js
@@ -86,37 +86,89 @@ describe("#filterProviders", () => {
 // strings to be used in the existing functions,
 // like filterProviders
 describe("#ammendProviders", () => {
+  let expectedResult = [
+    {
+      "endpoints":[
+        {
+          "formats":[
+            "json"
+          ],
+          "schemes":[
+            "http://instagram.com/p/*",
+            "http://instagr.am/p/*",
+            "http://www.instagram.com/p/*",
+            "http://www.instagr.am/p/*",
+            "https://instagram.com/p/*",
+            "https://instagr.am/p/*",
+            "https://www.instagram.com/p/*",
+            "https://www.instagr.am/p/*"
+          ],
+          "url":"https://api.instagram.com/oembed"
+        }
+      ],
+      "params":{
+        "hidecaption":true,
+        "omitscript":true
+      },
+      "provider_name":"Instagram",
+      "provider_url":"https://instagram.com"
+    },
+    {
+      "endpoints":[
+        {
+          "schemes":[
+            "http://www.kickstarter.com/projects/*"
+          ],
+          "url":"http://www.kickstarter.com/services/oembed"
+        }
+      ],
+      "params": {},
+      "provider_name":"Kickstarter",
+      "provider_url":"http://www.kickstarter.com"
+    },
+    {
+      "endpoints":[
+        {
+          "schemes":[
+            "https://twitter.com/*/status/*",
+            "https://*.twitter.com/*/status/*"
+          ],
+          "url":"https://publish.twitter.com/oembed"
+        }
+      ],
+      "params": {},
+      "provider_name":"Twitter",
+      "provider_url":"http://www.twitter.com/"
+    }
+  ]
+
   test("returns a list with Instagram, from extra provider config", () => {
-    let expectedResult = [{"endpoints": [{"formats": ["json"], "params": {}, "schemes": ["http://instagram.com/p/*", "http://instagr.am/p/*", "http://www.instagram.com/p/*", "http://www.instagr.am/p/*", "https://instagram.com/p/*", "https://instagr.am/p/*", "https://www.instagram.com/p/*", "https://www.instagr.am/p/*"], "url": "https://api.instagram.com/oembed"}], "params": {"hidecaption": true, "name": "Instagram", "omitscript": true}, "provider_name": "Instagram", "provider_url": "https://instagram.com"}, {"endpoints": [{"params": {}, "schemes": ["http://www.kickstarter.com/projects/*"], "url": "http://www.kickstarter.com/services/oembed"}], "provider_name": "Kickstarter", "provider_url": "http://www.kickstarter.com"}, {"endpoints": [{"params": {}, "schemes": ["https://twitter.com/*/status/*", "https://*.twitter.com/*/status/*"],"url": "https://publish.twitter.com/oembed"}], "provider_name": "Twitter", "provider_url": "http://www.twitter.com/"}]
     let verboseInstagramConfig = {
       name: 'Instagram',
       hidecaption: true,
       omitscript: true
     }
 
-    const result = ammendProviders(providers, {
+    const result = ammendProviders(providers.slice(0), {
       include: [verboseInstagramConfig]
     });
     
-    console.log(result[0].provider_name, result[1].endpoints.params)
     expect(result).toEqual(
       expect.arrayContaining(expectedResult),
     );
   });
   
   test("returns a list with Twitter and Instagram, from extra and regular config", () => {
-    let expectedResult = [{"endpoints": [{"formats": ["json"], "params": {}, "schemes": ["http://instagram.com/p/*", "http://instagr.am/p/*", "http://www.instagram.com/p/*", "http://www.instagr.am/p/*", "https://instagram.com/p/*", "https://instagr.am/p/*", "https://www.instagram.com/p/*", "https://www.instagr.am/p/*"], "url": "https://api.instagram.com/oembed"}], "params": {"hidecaption": true, "name": "Instagram", "omitscript": true}, "provider_name": "Instagram", "provider_url": "https://instagram.com"}, {"endpoints": [{"params": {}, "schemes": ["http://www.kickstarter.com/projects/*"], "url": "http://www.kickstarter.com/services/oembed"}], "provider_name": "Kickstarter", "provider_url": "http://www.kickstarter.com"}, {"endpoints": [{"params": {}, "schemes": ["https://twitter.com/*/status/*", "https://*.twitter.com/*/status/*"],"url": "https://publish.twitter.com/oembed"}], "provider_name": "Twitter", "provider_url": "http://www.twitter.com/"}]
     let verboseInstagramConfig = {
       name: 'Instagram',
       hidecaption: true,
       omitscript: true
     }
 
-    const result = ammendProviders(providers, {
+    const result = ammendProviders(providers.slice(0), {
       include: [verboseInstagramConfig, 'Twitter']
     });
   
-    console.log(result[0].provider_name, result[1].endpoints.params)
     expect(result).toEqual(
       expect.arrayContaining(expectedResult),
     );

--- a/helper.test.js
+++ b/helper.test.js
@@ -196,7 +196,7 @@ describe("#ammendOptions", () => {
   test("returns extended provider config as array of strings", () => {
     let result = ammendOptions({
       providers: {
-        include: [{ name: 'Twitter', darkTheme: true }],
+        include: [{ name: 'Twitter', theme: 'dark' }],
         exclude: [{ name: 'Instagram', showComments: false }]
       }
     })

--- a/helpers.js
+++ b/helpers.js
@@ -147,11 +147,22 @@ exports.fetchOembed = async (linkUrl, endpointUrl) => {
   const response = await axios.get(endpointUrl, {
     params: {
       format: "json",
-      url: linkUrl
+      url: linkUrl,
+      // Demo for Twitter
+
+      // cards: 'hidden', // Didn’t seem to work
+      conversation: 'none', // Didn’t seem to work
+      theme: 'dark',
+      link_color: '#897391',
+      omit_script: true, // Might only be for timeline?
+      maxwidth: 1000, // Might only be for timelines?
+      hide_media: true, // Works
+      dnt: true, // Do not track, difficult to tell if it really works 
     }
   });
   return response.data;
 };
+
 
 exports.selectPossibleOembedLinkNodes = markdownAST => {
   return select(markdownAST, "paragraph link:only-child");

--- a/helpers.js
+++ b/helpers.js
@@ -68,8 +68,8 @@ exports.fetchOembedProviders = async () => {
 exports.ammendProviders = (providers, rawOptions) => {
   let includedProvidersWithConfig = {}
 
-  if (rawOptions.providers && rawOptions.providers.include && rawOptions.providers.include.length >= 1) {
-    rawOptions.providers.include.forEach(config => {
+  if (rawOptions && rawOptions.include && rawOptions.include.length >= 1) {
+    rawOptions.include.forEach(config => {
       if (typeof config === 'object' && config.name) {
         let { name, ...urlParams } = config
         includedProvidersWithConfig[name] = urlParams
@@ -115,12 +115,12 @@ exports.ammendProviders = (providers, rawOptions) => {
     const providerName = provider.provider_name;
     provider.endpoints = ammendEndpoints(provider.endpoints, providerName).map(
       endpoint => {
-        endpoint.params = ammendParamsFromOptions(providerName);
         endpoint.schemes = ammendSchemes(endpoint.schemes, providerName);
         endpoint.url = ammendEndpointUrl(endpoint.url, providerName);
         return endpoint;
       }
     );
+    provider.params = ammendParamsFromOptions(providerName);
     return provider;
   });
 };
@@ -166,7 +166,7 @@ exports.getProviderEndpointUrlForLinkUrl = (linkUrl, providers) => {
           const regExp = new RegExp(schema);
           if (regExp.test(linkUrl)) {
             endpointObj = {
-              params: endpoint.params || {},
+              params: provider.params || {},
               url: endpoint.url
             }
           }

--- a/helpers.js
+++ b/helpers.js
@@ -82,39 +82,36 @@ exports.ammendProviders = providers => {
   });
 };
 
-exports.filterProviders = (providers, filter) => {
-  if (!filter) return providers;
+exports.filterProviders = (providers, listConfig) => {
+  if (!listConfig) return providers;
 
   const filterFunc = (provider, filter, exclude) => {
     if (!filter) return true;
-
-    let filterIncludes = []
-    let filterExcludes = []
-
-    filter.forEach((providerConfig) => {
-      if (typeof providerConfig === 'string') {
-        if (providerConfig.includes(providerConfig)) {
-          filterIncludes.push(providerConfig)
-        } else {
-          filterExcludes.push(providerConfig)          
-        }
-      } else if (typeof providerConfig === 'object') {
-        // Handles includes/excludes where there are
-        // config objects for the provider
-        if (providerConfig.name.includes(provider.provider_name)) {
-          filterIncludes.push(providerConfig);
-        } else {
-          filterExcludes.push(providerConfig);
-        }
-      }
-    })
-    
-    return exclude ? filterExcludes : filterIncludes;
+  
+    const filterIncludes = filter.includes(provider.provider_name);
+    return exclude ? !filterIncludes : filterIncludes;
   };
+  
+  const formatFunc = (list) => {
+    if (list && list.length >= 1) {
+      console.log('list', list)
+      list = list.map((item) => {
+        if (typeof item === 'object' && item.name) {
+          console.log('item', item)
+          return item.name
+        }
+        
+        return item
+      })
+    }
+    return list
+  }
+  
+  let result = providers
+    .filter(provider => filterFunc(provider, formatFunc(listConfig.include)))
+    .filter(provider => filterFunc(provider, formatFunc(listConfig.exclude), true));
 
-  return providers
-    .filter(provider => filterFunc(provider, filter.include))
-    .filter(provider => filterFunc(provider, filter.exclude, true));
+  return result
 };
 
 exports.filterProviderKeys = (keys, filter) => {

--- a/helpers.js
+++ b/helpers.js
@@ -88,8 +88,28 @@ exports.filterProviders = (providers, filter) => {
   const filterFunc = (provider, filter, exclude) => {
     if (!filter) return true;
 
-    const filterIncludes = filter.includes(provider.provider_name);
-    return exclude ? !filterIncludes : filterIncludes;
+    let filterIncludes = []
+    let filterExcludes = []
+
+    filter.forEach((providerConfig) => {
+      if (typeof providerConfig === 'string') {
+        if (providerConfig.includes(providerConfig)) {
+          filterIncludes.push(providerConfig)
+        } else {
+          filterExcludes.push(providerConfig)          
+        }
+      } else if (typeof providerConfig === 'object') {
+        // Handles includes/excludes where there are
+        // config objects for the provider
+        if (providerConfig.name.includes(provider.provider_name)) {
+          filterIncludes.push(providerConfig);
+        } else {
+          filterExcludes.push(providerConfig);
+        }
+      }
+    })
+    
+    return exclude ? filterExcludes : filterIncludes;
   };
 
   return providers

--- a/helpers.js
+++ b/helpers.js
@@ -34,9 +34,10 @@ const DEFAULT_OPTIONS = {
 
 exports.ammendOptions = options => {
   const formatFunc = (list) => {
-    let result = []
+    let result = undefined
 
     if (list && list.length >= 1) {
+      result = []
       list.forEach((item) => {
         if (typeof item === 'object' && item.name) {
           result.push(item.name)

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const Promise = require("bluebird");
 
 const {
   fetchOembed,
-  getProviderEndpointUrlForLinkUrl,
+  getProviderEndpointForLinkUrl,
   selectPossibleOembedLinkNodes,
   tranformsLinkNodeToOembedNode
 } = require("./helpers");
@@ -26,9 +26,10 @@ const processNode = async (node, providers) => {
   try {
     console.log(`Process node ${node.url}`);
     // Check if url matched any of the oembed url schemes.
-    const endpointUrl = getProviderEndpointUrlForLinkUrl(node.url, providers);
+    const endpoint = getProviderEndpointForLinkUrl(node.url, providers);
+    console.log(`With oembed request ${JSON.stringify(endpoint)}`);
     // Fetch the oembed response from the oembed provider.
-    const oembedResponse = await fetchOembed(node.url, endpointUrl);
+    const oembedResponse = await fetchOembed(endpoint);
     // Transform the link node into an html node.
     tranformsLinkNodeToOembedNode(node, oembedResponse);
   } catch (error) {


### PR DESCRIPTION
Hi, thanks for your work on this plugin, it’s working really well for me!

Before I went too far with this, I was wondering what you thought about adding support for configuring individual oEmbed providers? As far as I could tell, this isn’t possible with the current plugin, although if I’ve missed something just let me know.

I’ve hard-coded a Twitter example in `helpers.js` just as an easy way to try this idea out, but I would expect you would manually do something like this in your `gatsby-config.js`:

```js
// …
{
  resolve: `@raae/gatsby-remark-oembed`,
  options: {
    providers: {
      include: [
        {
          name: 'Twitter', // Maybe resolve instead of name?
          options: {
            theme: 'dark' // Use the Twitter dark theme
            dnt: true // Do not track
            hide_media: true // Hide Twitter card media
          }
        },
        'Instagram'
      ],
    },
  },
}
// …
```

On Twitter, this will let you configure some of the parameters you would normally change through `data-*` attributes, which of course don’t make sense here, because the HTML is generated for you. Another API I could imagine:

```
https://twitter.com/kennethormandy/status/1234?theme=dark
```

Or related to #23:

```
oembed:https://twitter.com/kennethormandy/status/1234?theme=dark
```

Presumably, this would let you configure the settings for each individual embed, if you wanted something different between them. Personally, my use case would be solved with the global settings in `gatsby-config.js`, but I could see this being useful too.

<!--

For example, with CodePen embed settings, [you could set heights](https://blog.codepen.io/documentation/api/oembed/), or with Instagram, you should be able to [enable or disable the caption](https://www.instagram.com/developer/embedding/) which can be very useful when you want to embed the photo with credit but not include the many hashtags someone has tacked onto the description.

-->

Looking forward to hearing what you think.