### PR TITLE
feature: `usePrefix` can be false, true or array of prefixes - solves #47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .vscode
 coverage
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ plugins: [
         {
           resolve: `@raae/gatsby-remark-oembed`,
           options: {
-            // defaults to false
-            usePrefix: true,
+            // usePrefix defaults to false
+            // usePrefix: true is the same as ["oembed"]
+            usePrefix: ["oembed", "video"],
             providers: {
               // Important to exclude providers
               // that adds js to the page.
@@ -102,6 +103,30 @@ Its pretty cool :D
 
 Links must be surrounded by empty lines.
 
+#### With setting `usePrefix: array of prefixes`
+
+If you would like to use a prefix other than "oembed" or multiple prefixes you can set `usePrefix` to an array of custom prefixes. This can be beneficial when converting from other embed plugins.
+
+`usePrefix: ["embed", "video", "oembed"]`
+
+```md
+// In your markdown file
+
+Check it out! I can use the prefix "oembed:"
+
+`oembed: https://twitter.com/raae/status/1045394833001652225`
+
+Or I can use the prefix "embed:" if I like ;)
+
+`embed: https://www.instagram.com/p/Bof9WhgBmY2/`
+
+I can also use "video:" like I did before with `gatsby-remark-video`.
+
+`video: https://vimeo.com/42672205`
+```
+
+`usePrefix: true` in the section above is the same as `usePrefix: ["oembed"]`.
+
 #### With setting `usePrefix: false`
 
 ```md
@@ -122,7 +147,7 @@ Links must be surrounded by empty lines.
 
 | Name                 | Type                        | Description                                                 |
 | -------------------- | --------------------------- | ----------------------------------------------------------- |
-| `usePrefix`          | Boolean                     | See above section on content                                |
+| `usePrefix`          | Boolean / Array of prefixes | See above section on content                                |
 | `providers.include`  | Array of provider keys      | Only links from providers on this list will be transformed. |
 | `providers.exclude`  | Array of provider keys      | Links from providers on this list will not be transformed.  |
 | `providers.settings` | Object of provider settings | Optional configuration unique to each provider.             |

--- a/utils/.test/markdown.js
+++ b/utils/.test/markdown.js
@@ -143,7 +143,7 @@ module.exports = {
       children: [
         {
           type: "inlineCode",
-          value: "oembed:https://www.instagram.com/p/Bof9WhgBmY2",
+          value: "video:https://www.instagram.com/p/Bof9WhgBmY2",
           position: {
             start: { line: 10, column: 1, offset: 224 },
             end: { line: 10, column: 49, offset: 272 },

--- a/utils/.test/markdown.js
+++ b/utils/.test/markdown.js
@@ -1,3 +1,8 @@
+// link - youtube
+// inlineCode with "oembed: " prefix - twitter
+// inlineCode with without prefix - instagram
+// inlineCode with "video:" - twitch
+
 module.exports = {
   type: "root",
   children: [
@@ -26,11 +31,11 @@ module.exports = {
         {
           type: "link",
           title: null,
-          url: "https://www.instagram.com/p/Bof9WhgBmY2",
+          url: "http://www.youtube.com/watch?v=iwGFalTRHDA",
           children: [
             {
               type: "text",
-              value: "https://www.instagram.com/p/Bof9WhgBmY2",
+              value: "http://www.youtube.com/watch?v=iwGFalTRHDA",
               position: {
                 start: { line: 4, column: 1, offset: 54 },
                 end: { line: 4, column: 40, offset: 93 },
@@ -124,7 +129,7 @@ module.exports = {
       children: [
         {
           type: "inlineCode",
-          value: "https://twitter.com/raae/status/1045394833001652225",
+          value: "https://www.instagram.com/p/Bof9WhgBmY2",
           position: {
             start: { line: 8, column: 1, offset: 161 },
             end: { line: 8, column: 62, offset: 222 },
@@ -143,7 +148,7 @@ module.exports = {
       children: [
         {
           type: "inlineCode",
-          value: "video:https://www.instagram.com/p/Bof9WhgBmY2",
+          value: "video:https://www.twitch.tv/videos/72749628",
           position: {
             start: { line: 10, column: 1, offset: 224 },
             end: { line: 10, column: 49, offset: 272 },

--- a/utils/amendOptions.js
+++ b/utils/amendOptions.js
@@ -1,6 +1,6 @@
 const { defaultsDeep } = require("lodash");
 
-const DEFAULT_USE_PREFIX = ["oembed:"];
+const DEFAULT_USE_PREFIX = ["oembed"];
 
 const DEFAULT_OPTIONS = {
   usePrefix: false

--- a/utils/amendOptions.js
+++ b/utils/amendOptions.js
@@ -1,10 +1,17 @@
 const { defaultsDeep } = require("lodash");
 
+const DEFAULT_USE_PREFIX = ["oembed:"];
+
 const DEFAULT_OPTIONS = {
-  usePrefix: ["oembed:"]
+  usePrefix: false
 };
 
 const amendOptions = options => {
+  if (options.usePrefix && !Array.isArray(options.usePrefix)) {
+    // usePrefix: true
+    options.usePrefix = DEFAULT_USE_PREFIX;
+  }
+
   return defaultsDeep({}, options, DEFAULT_OPTIONS);
 };
 

--- a/utils/amendOptions.js
+++ b/utils/amendOptions.js
@@ -1,7 +1,7 @@
 const { defaultsDeep } = require("lodash");
 
 const DEFAULT_OPTIONS = {
-  usePrefix: ['oembed:']
+  usePrefix: ["oembed:"]
 };
 
 const amendOptions = options => {

--- a/utils/amendOptions.js
+++ b/utils/amendOptions.js
@@ -1,7 +1,7 @@
 const { defaultsDeep } = require("lodash");
 
 const DEFAULT_OPTIONS = {
-  usePrefix: false
+  usePrefix: ['oembed:']
 };
 
 const amendOptions = options => {

--- a/utils/amendOptions.test.js
+++ b/utils/amendOptions.test.js
@@ -1,35 +1,77 @@
 const amendOptions = require("./amendOptions");
 
-test("options amended correctly", () => {
-  const rawOptions = {
-    usePrefix: ["oembed:", "video:"],
-    providers: {
-      include: ["Instagram"],
-      settings: {
-        Twitter: {
-          theme: "dark" // Use the Twitter dark theme
-        },
-        Codepen: {
-          height: 200
+describe("#amendProviders", () => {
+  test("no change to default options", () => {
+    const rawOptions = {};
+    const amendedOptions = {
+      usePrefix: false
+    };
+
+    expect(amendOptions(rawOptions)).toEqual(amendedOptions);
+  });
+
+  test("usePrefix = 'true' amended correctly", () => {
+    const rawOptions = {
+      usePrefix: true
+    };
+
+    const amendedOptions = {
+      usePrefix: ["oembed:"]
+    };
+
+    expect(amendOptions(rawOptions)).toEqual(amendedOptions);
+  });
+
+  test("usePrefix = <array> amended correctly", () => {
+    const rawOptions1 = {
+      usePrefix: ["oembed:", "video:"]
+    };
+
+    const amendedOptions1 = {
+      usePrefix: ["oembed:", "video:"]
+    };
+
+    const rawOptions2 = {
+      usePrefix: ["video:"]
+    };
+
+    const amendedOptions2 = {
+      usePrefix: ["video:"]
+    };
+
+    expect(amendOptions(rawOptions1)).toEqual(amendedOptions1);
+    expect(amendOptions(rawOptions2)).toEqual(amendedOptions2);
+  });
+
+  test("other options amended correctly", () => {
+    const rawOptions = {
+      providers: {
+        include: ["Instagram"],
+        settings: {
+          Twitter: {
+            theme: "dark" // Use the Twitter dark theme
+          },
+          Codepen: {
+            height: 200
+          }
         }
       }
-    }
-  };
+    };
 
-  const amendedOptions = {
-    usePrefix: ["oembed:", "video:"],
-    providers: {
-      include: ["Instagram"],
-      settings: {
-        Twitter: {
-          theme: "dark" // Use the Twitter dark theme
-        },
-        Codepen: {
-          height: 200
+    const amendedOptions = {
+      providers: {
+        include: ["Instagram"],
+        settings: {
+          Twitter: {
+            theme: "dark" // Use the Twitter dark theme
+          },
+          Codepen: {
+            height: 200
+          }
         }
       }
-    }
-  };
+    };
 
-  expect(amendOptions(rawOptions)).toEqual(amendedOptions);
+    expect(amendOptions(rawOptions)).toMatchObject(amendedOptions);
+  });
 });

--- a/utils/amendOptions.test.js
+++ b/utils/amendOptions.test.js
@@ -16,7 +16,7 @@ describe("#amendProviders", () => {
     };
 
     const amendedOptions = {
-      usePrefix: ["oembed:"]
+      usePrefix: ["oembed"]
     };
 
     expect(amendOptions(rawOptions)).toEqual(amendedOptions);
@@ -24,19 +24,19 @@ describe("#amendProviders", () => {
 
   test("usePrefix = <array> amended correctly", () => {
     const rawOptions1 = {
-      usePrefix: ["oembed:", "video:"]
+      usePrefix: ["oembed", "video"]
     };
 
     const amendedOptions1 = {
-      usePrefix: ["oembed:", "video:"]
+      usePrefix: ["oembed", "video"]
     };
 
     const rawOptions2 = {
-      usePrefix: ["video:"]
+      usePrefix: ["video"]
     };
 
     const amendedOptions2 = {
-      usePrefix: ["video:"]
+      usePrefix: ["video"]
     };
 
     expect(amendOptions(rawOptions1)).toEqual(amendedOptions1);

--- a/utils/amendOptions.test.js
+++ b/utils/amendOptions.test.js
@@ -2,7 +2,7 @@ const amendOptions = require("./amendOptions");
 
 test("options amended correctly", () => {
   const rawOptions = {
-    usePrefix: true,
+    usePrefix: ["oembed:", "video:"],
     providers: {
       include: ["Instagram"],
       settings: {
@@ -17,7 +17,7 @@ test("options amended correctly", () => {
   };
 
   const amendedOptions = {
-    usePrefix: true,
+    usePrefix: ["oembed:", "video:"],
     providers: {
       include: ["Instagram"],
       settings: {

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -5,12 +5,13 @@ const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = ['oembed:']) => 
   var res = [];
   nodes.map(node => {
     usePrefix.map(prefix => {
-      if (!node.value.startsWith(prefix)) return;
-    })
-    node.url = node.value.split(':');
-    node.url.shift();
-    node.url = node.url.join(':').trim();
-    res.push(node);
+      if (node.value.startsWith(prefix)) {
+        node.url = node.value.split(':');
+        node.url.shift();
+        node.url = node.url.join(':').trim();
+        return res.push(node);
+      }
+    });
   });
   return res;
 };

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -5,20 +5,17 @@ const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = false) => {
     return select(markdownAST, "paragraph link:only-child");
   } else {
     const inlineCodeNodes = select(markdownAST, "inlineCode");
-    return inlineCodeNodes
-      .filter(inlineCodeNode => {
-        // Returns true if the value starts with any of the prefixes
-        return usePrefix.find(prefix =>
-          inlineCodeNode.value.startsWith(prefix)
-        );
-      })
-      .map(inlineCodeNode => {
-        // Remove everything before first ":"
-        inlineCodeNode.url = inlineCodeNode.value.split(":");
-        inlineCodeNode.url.shift();
-        inlineCodeNode.url = inlineCodeNode.url.join(":").trim();
-        return inlineCodeNode;
-      });
+    const selectedNodes = [];
+
+    inlineCodeNodes.forEach(inlineCodeNode => {
+      const [prefix, ...rest] = inlineCodeNode.value.split(":");
+      if (usePrefix.includes(prefix.trim())) {
+        inlineCodeNode.url = rest.join(":").trim();
+        selectedNodes.push(inlineCodeNode);
+      }
+    });
+
+    return selectedNodes;
   }
 };
 

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -2,19 +2,28 @@ const select = require("unist-util-select");
 
 const selectPossibleOembedLinkNodes = (
   markdownAST,
-  usePrefix = ["oembed:"]
+  usePrefix = false
 ) => {
   const nodes = select(markdownAST, "inlineCode");
   var res = [];
   nodes.map(node => {
-    usePrefix.map(prefix => {
-      if (node.value.startsWith(prefix)) {
-        node.url = node.value.split(":");
-        node.url.shift();
-        node.url = node.url.join(":").trim();
-        return res.push(node);
-      }
-    });
+    if (usePrefix === false) {
+      return select(markdownAST, "paragraph link:only-child");
+    } else if (usePrefix === true) {
+      if (!node.value.startsWith("oembed:")) return;
+      node.url = node.value.substring(7).trim();
+      res.push(node);
+      return res;
+    } else {
+      usePrefix.map(prefix => {
+        if (node.value.startsWith(prefix)) {
+          node.url = node.value.split(":");
+          node.url.shift();
+          node.url = node.url.join(":").trim();
+          return res.push(node);
+        }
+      });
+    }
   });
   return res;
 };

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -1,28 +1,25 @@
 const select = require("unist-util-select");
 
 const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = false) => {
-  const nodes = select(markdownAST, "inlineCode");
-  var res = [];
-  nodes.map(node => {
-    if (usePrefix === false) {
-      return select(markdownAST, "paragraph link:only-child");
-    } else if (usePrefix === true) {
-      if (!node.value.startsWith("oembed:")) return;
-      node.url = node.value.substring(7).trim();
-      res.push(node);
-      return res;
-    } else {
-      usePrefix.map(prefix => {
-        if (node.value.startsWith(prefix)) {
-          node.url = node.value.split(":");
-          node.url.shift();
-          node.url = node.url.join(":").trim();
-          return res.push(node);
-        }
+  if (!usePrefix) {
+    return select(markdownAST, "paragraph link:only-child");
+  } else {
+    const inlineCodeNodes = select(markdownAST, "inlineCode");
+    return inlineCodeNodes
+      .filter(inlineCodeNode => {
+        // Returns true if the value starts with any of the prefixes
+        return usePrefix.find(prefix =>
+          inlineCodeNode.value.startsWith(prefix)
+        );
+      })
+      .map(inlineCodeNode => {
+        // Remove everything before first ":"
+        inlineCodeNode.url = inlineCodeNode.value.split(":");
+        inlineCodeNode.url.shift();
+        inlineCodeNode.url = inlineCodeNode.url.join(":").trim();
+        return inlineCodeNode;
       });
-    }
-  });
-  return res;
+  }
 };
 
 module.exports = selectPossibleOembedLinkNodes;

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -1,9 +1,6 @@
 const select = require("unist-util-select");
 
-const selectPossibleOembedLinkNodes = (
-  markdownAST,
-  usePrefix = false
-) => {
+const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = false) => {
   const nodes = select(markdownAST, "inlineCode");
   var res = [];
   nodes.map(node => {

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -1,18 +1,18 @@
 const select = require("unist-util-select");
 
-const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = false) => {
-  if (usePrefix === true) {
-    const nodes = select(markdownAST, "inlineCode");
-    var res = [];
-    nodes.map(node => {
-      if (!node.value.startsWith("oembed:")) return;
-      node.url = node.value.substring(7).trim();
-      res.push(node);
-    });
-    return res;
-  } else {
-    return select(markdownAST, "paragraph link:only-child");
-  }
+const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = ['oembed:']) => {
+  const nodes = select(markdownAST, "inlineCode");
+  var res = [];
+  nodes.map(node => {
+    usePrefix.map(prefix => {
+      if (!node.value.startsWith(prefix)) return;
+    })
+    node.url = node.value.split(':');
+    node.url.shift();
+    node.url = node.url.join(':').trim();
+    res.push(node);
+  });
+  return res;
 };
 
 module.exports = selectPossibleOembedLinkNodes;

--- a/utils/selectPossibleOembedLinkNodes.js
+++ b/utils/selectPossibleOembedLinkNodes.js
@@ -1,14 +1,17 @@
 const select = require("unist-util-select");
 
-const selectPossibleOembedLinkNodes = (markdownAST, usePrefix = ['oembed:']) => {
+const selectPossibleOembedLinkNodes = (
+  markdownAST,
+  usePrefix = ["oembed:"]
+) => {
   const nodes = select(markdownAST, "inlineCode");
   var res = [];
   nodes.map(node => {
     usePrefix.map(prefix => {
       if (node.value.startsWith(prefix)) {
-        node.url = node.value.split(':');
+        node.url = node.value.split(":");
         node.url.shift();
-        node.url = node.url.join(':').trim();
+        node.url = node.url.join(":").trim();
         return res.push(node);
       }
     });

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -1,16 +1,41 @@
 const selectPossibleOembedLinkNodes = require("./selectPossibleOembedLinkNodes");
 const MARKDOWN_AST = require("./.test/markdown");
 
+// link - youtube
+// inlineCode with "oembed: " prefix - twitter
+// inlineCode with without prefix - instagram
+// inlineCode with "video:" - twitch
+
 describe("#selectPossibleOembedLinkNodes", () => {
   test("select only links that are the only child of a paragraph", () => {
-    const possibleOembedLinks = selectPossibleOembedLinkNodes(
-      MARKDOWN_AST,
-      true
-    );
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST);
     expect(possibleOembedLinks).toHaveLength(1);
+    expect(possibleOembedLinks[0]).toMatchObject({
+      type: "link",
+      url: "http://www.youtube.com/watch?v=iwGFalTRHDA"
+    });
+  });
+
+  test("select only links that inline code and prefixed with 'oembed:'", () => {
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
+      "oembed:"
+    ]);
+    expect(possibleOembedLinks).toHaveLength(1);
+    // allow space after 'oembed:'
     expect(possibleOembedLinks[0]).toMatchObject({
       type: "inlineCode",
       url: "https://twitter.com/raae/status/1045394833001652225"
+    });
+  });
+
+  test("select only links that inline code and prefixed with 'video:'", () => {
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
+      "video:"
+    ]);
+    expect(possibleOembedLinks).toHaveLength(1);
+    expect(possibleOembedLinks[0]).toMatchObject({
+      type: "inlineCode",
+      url: "https://www.twitch.tv/videos/72749628"
     });
   });
 
@@ -27,7 +52,7 @@ describe("#selectPossibleOembedLinkNodes", () => {
     });
     expect(possibleOembedLinks[1]).toMatchObject({
       type: "inlineCode",
-      url: "https://www.instagram.com/p/Bof9WhgBmY2"
+      url: "https://www.twitch.tv/videos/72749628"
     });
   });
 });

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -3,7 +3,7 @@ const MARKDOWN_AST = require("./.test/markdown");
 
 describe("#selectPossibleOembedLinkNodes", () => {
   test("select only links that are the only child of a paragraph", () => {
-    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST);
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, true);
     expect(possibleOembedLinks).toHaveLength(1);
     expect(possibleOembedLinks[0]).toMatchObject({
       type: "inlineCode",

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -4,7 +4,7 @@ const MARKDOWN_AST = require("./.test/markdown");
 // link - youtube
 // inlineCode with "oembed: " prefix - twitter
 // inlineCode with without prefix - instagram
-// inlineCode with "video:" - twitch
+// inlineCode with "video" - twitch
 
 describe("#selectPossibleOembedLinkNodes", () => {
   test("select only links that are the only child of a paragraph", () => {
@@ -18,7 +18,7 @@ describe("#selectPossibleOembedLinkNodes", () => {
 
   test("select only links that inline code and prefixed with 'oembed:'", () => {
     const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
-      "oembed:"
+      "oembed"
     ]);
     expect(possibleOembedLinks).toHaveLength(1);
     // allow space after 'oembed:'
@@ -30,7 +30,7 @@ describe("#selectPossibleOembedLinkNodes", () => {
 
   test("select only links that inline code and prefixed with 'video:'", () => {
     const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
-      "video:"
+      "video"
     ]);
     expect(possibleOembedLinks).toHaveLength(1);
     expect(possibleOembedLinks[0]).toMatchObject({
@@ -41,8 +41,8 @@ describe("#selectPossibleOembedLinkNodes", () => {
 
   test("select only links that inline code and prefixed with 'oembed:' or 'video:'", () => {
     const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
-      "oembed:",
-      "video:"
+      "oembed",
+      "video"
     ]);
     expect(possibleOembedLinks).toHaveLength(2);
     // allow space after 'oembed:'

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -12,10 +12,10 @@ describe("#selectPossibleOembedLinkNodes", () => {
   });
 
   test("select only links that inline code and prefixed with 'oembed:' or 'video:'", () => {
-    const possibleOembedLinks = selectPossibleOembedLinkNodes(
-      MARKDOWN_AST,
-      ["oembed:", "video:"]
-    );
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, [
+      "oembed:",
+      "video:"
+    ]);
     expect(possibleOembedLinks).toHaveLength(2);
     // allow space after 'oembed:'
     expect(possibleOembedLinks[0]).toMatchObject({

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -3,7 +3,10 @@ const MARKDOWN_AST = require("./.test/markdown");
 
 describe("#selectPossibleOembedLinkNodes", () => {
   test("select only links that are the only child of a paragraph", () => {
-    const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST, true);
+    const possibleOembedLinks = selectPossibleOembedLinkNodes(
+      MARKDOWN_AST,
+      true
+    );
     expect(possibleOembedLinks).toHaveLength(1);
     expect(possibleOembedLinks[0]).toMatchObject({
       type: "inlineCode",

--- a/utils/selectPossibleOembedLinkNodes.test.js
+++ b/utils/selectPossibleOembedLinkNodes.test.js
@@ -6,22 +6,22 @@ describe("#selectPossibleOembedLinkNodes", () => {
     const possibleOembedLinks = selectPossibleOembedLinkNodes(MARKDOWN_AST);
     expect(possibleOembedLinks).toHaveLength(1);
     expect(possibleOembedLinks[0]).toMatchObject({
-      type: "link",
-      url: "https://www.instagram.com/p/Bof9WhgBmY2"
+      type: "inlineCode",
+      url: "https://twitter.com/raae/status/1045394833001652225"
     });
   });
 
-  test("select only links that inline code and prefixed with 'oembed:'", () => {
+  test("select only links that inline code and prefixed with 'oembed:' or 'video:'", () => {
     const possibleOembedLinks = selectPossibleOembedLinkNodes(
       MARKDOWN_AST,
-      true
+      ["oembed:", "video:"]
     );
     expect(possibleOembedLinks).toHaveLength(2);
+    // allow space after 'oembed:'
     expect(possibleOembedLinks[0]).toMatchObject({
       type: "inlineCode",
       url: "https://twitter.com/raae/status/1045394833001652225"
     });
-    // allow space after 'oembed:'
     expect(possibleOembedLinks[1]).toMatchObject({
       type: "inlineCode",
       url: "https://www.instagram.com/p/Bof9WhgBmY2"


### PR DESCRIPTION
This substitutes @rayriffy's PR #72. 

Updated tests and did some small refactoring of @rayriffy's code.

Example array of prefixes: ["oembed", "video"].