### PR TITLE
add socks5 proxy 👻

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "axios": "^0.19.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.14",
+    "socks-proxy-agent": "^4.0.2",
     "unist-util-select": "^1.5.0"
   },
   "devDependencies": {

--- a/utils/amendOptions.js
+++ b/utils/amendOptions.js
@@ -3,7 +3,8 @@ const { defaultsDeep } = require("lodash");
 const DEFAULT_USE_PREFIX = ["oembed"];
 
 const DEFAULT_OPTIONS = {
-  usePrefix: false
+  usePrefix: false,
+  useProxy: false
 };
 
 const amendOptions = options => {

--- a/utils/amendOptions.test.js
+++ b/utils/amendOptions.test.js
@@ -4,7 +4,8 @@ describe("#amendProviders", () => {
   test("no change to default options", () => {
     const rawOptions = {};
     const amendedOptions = {
-      usePrefix: false
+      usePrefix: false,
+      useProxy: false
     };
 
     expect(amendOptions(rawOptions)).toEqual(amendedOptions);
@@ -16,7 +17,8 @@ describe("#amendProviders", () => {
     };
 
     const amendedOptions = {
-      usePrefix: ["oembed"]
+      usePrefix: ["oembed"],
+      useProxy: false
     };
 
     expect(amendOptions(rawOptions)).toEqual(amendedOptions);
@@ -28,7 +30,8 @@ describe("#amendProviders", () => {
     };
 
     const amendedOptions1 = {
-      usePrefix: ["oembed", "video"]
+      usePrefix: ["oembed", "video"],
+      useProxy: false
     };
 
     const rawOptions2 = {
@@ -36,11 +39,31 @@ describe("#amendProviders", () => {
     };
 
     const amendedOptions2 = {
-      usePrefix: ["video"]
+      usePrefix: ["video"],
+      useProxy: false
     };
 
     expect(amendOptions(rawOptions1)).toEqual(amendedOptions1);
     expect(amendOptions(rawOptions2)).toEqual(amendedOptions2);
+  });
+
+  test("useProxy = an Object", () => {
+    const rawOptions = {
+      useProxy: {
+        host: "1.1.1.1",
+        port: "1111",
+        useSocks5: false
+      }
+    };
+    const amendedOptions = {
+      usePrefix: false,
+      useProxy: {
+        host: "1.1.1.1",
+        port: "1111",
+        useSocks5: false
+      }
+    };
+    expect(amendOptions(rawOptions)).toEqual(amendedOptions);
   });
 
   test("other options amended correctly", () => {

--- a/utils/fetchOembed.js
+++ b/utils/fetchOembed.js
@@ -1,11 +1,30 @@
 const axios = require("axios");
 
-const fetchOembed = async endpoint => {
+const fetchOembed = async (endpoint, proxyAgent) => {
+  let proxy = {};
+  if (proxyAgent) {
+    // has proxy
+    if (proxyAgent.useSocks5) {
+      proxy = {
+        httpAgent: proxyAgent.agent,
+        httpsAgent: proxyAgent.agent
+      };
+    } else {
+      proxy = {
+        proxy: {
+          ...proxyAgent
+        }
+      };
+      // no need of useSocks5 in axios proxy configuration
+      delete proxy.proxy.useSocks5;
+    }
+  }
   const response = await axios.get(endpoint.url, {
     params: {
       format: "json",
       ...endpoint.params
-    }
+    },
+    ...proxy
   });
   return response.data;
 };

--- a/utils/fetchOembed.test.js
+++ b/utils/fetchOembed.test.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const MockAdapter = require("axios-mock-adapter");
+const SocksProxyAgent = require("socks-proxy-agent");
 const fetchOembed = require("./fetchOembed");
 
 const mock = new MockAdapter(axios);
@@ -39,6 +40,41 @@ describe("#fetchOembed", () => {
     mock.onGet(endpoint.url).reply(200, response);
 
     fetchOembed(endpoint).then(() => {
+      expect(mock.history.get[0].params).toEqual({
+        url: "https://www.instagram.com/p/BftIg_OFPFX/",
+        format: "json"
+      });
+      done();
+    });
+  });
+
+  test("call axios with socks5 proxy", done => {
+    const socks5 = `socks5://127.0.0.1:9527`;
+    const socks5Proxy = new SocksProxyAgent(socks5);
+    const proxyAgent = {
+      useSocks5: true,
+      agent: socks5Proxy
+    };
+
+    mock.onGet(endpoint.url).reply(200, response);
+    fetchOembed(endpoint, proxyAgent).then(() => {
+      expect(mock.history.get[0].params).toEqual({
+        url: "https://www.instagram.com/p/BftIg_OFPFX/",
+        format: "json"
+      });
+      done();
+    });
+  });
+
+  test("call axios with normal proxy", done => {
+    const proxyAgent = {
+      host: "127.0.0.1",
+      port: "9528",
+      useSocks5: false
+    };
+
+    mock.onGet(endpoint.url).reply(200, response);
+    fetchOembed(endpoint, proxyAgent).then(() => {
       expect(mock.history.get[0].params).toEqual({
         url: "https://www.instagram.com/p/BftIg_OFPFX/",
         format: "json"

--- a/utils/getProxyAgent.js
+++ b/utils/getProxyAgent.js
@@ -1,0 +1,22 @@
+const { defaultsDeep } = require("lodash");
+const SocksProxyAgent = require("socks-proxy-agent");
+
+const DEFAULT_PROXY = {
+  host: "127.0.0.1",
+  port: "1080",
+  useSocks5: true
+};
+
+const getProxyAgent = useProxy => {
+  if (!useProxy) {
+    return false;
+  }
+  let proxyAgent = defaultsDeep({}, useProxy, DEFAULT_PROXY);
+  if (proxyAgent.useSocks5) {
+    const socks5Proxy = `socks://${proxyAgent.host}:${proxyAgent.port}`;
+    proxyAgent.agent = new SocksProxyAgent(socks5Proxy);
+  }
+  return proxyAgent;
+};
+
+module.exports = getProxyAgent;

--- a/utils/getProxyAgent.test.js
+++ b/utils/getProxyAgent.test.js
@@ -1,0 +1,74 @@
+const getProxyAgent = require("./getProxyAgent");
+
+describe("#getProxyAgent", () => {
+  test("useProxy = false ", () => {
+    const useProxy = false;
+    expect(getProxyAgent(useProxy)).toBeFalsy();
+  });
+
+  test("useProxy = {} ", () => {
+    const useProxy = {};
+    const proxyAgent = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: true,
+      agent: {}
+    };
+    const res = getProxyAgent(useProxy);
+    expect(res).toMatchObject(proxyAgent);
+    expect(res).toHaveProperty("agent");
+  });
+
+  test("useProxy = an Object without socks5", () => {
+    const useProxy = {
+      host: "127.0.0.1",
+      port: "1080"
+    };
+    const proxyAgent = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: true
+    };
+    const res = getProxyAgent(useProxy);
+    expect(res).toMatchObject(proxyAgent);
+    expect(res).toHaveProperty("agent");
+  });
+
+  test("useProxy = an Object with useSocks5 on", () => {
+    const useProxy = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: true
+    };
+    const proxyAgent = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: true
+    };
+    const res = getProxyAgent(useProxy);
+    expect(res).toMatchObject(proxyAgent);
+    expect(res).toHaveProperty("agent");
+  });
+
+  test("useProxy = an Object with useSocks5 off", () => {
+    const useProxy = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: false,
+      auth: {
+        username: "foo",
+        password: "123"
+      }
+    };
+    const proxyAgent = {
+      host: "127.0.0.1",
+      port: "1080",
+      useSocks5: false,
+      auth: {
+        username: "foo",
+        password: "123"
+      }
+    };
+    expect(getProxyAgent(useProxy)).toEqual(proxyAgent);
+  });
+});

--- a/utils/index.js
+++ b/utils/index.js
@@ -8,6 +8,7 @@ const getProviderEndpointForLinkUrl = require("./getProviderEndpointForLinkUrl")
 const selectPossibleOembedLinkNodes = require("./selectPossibleOembedLinkNodes");
 const tranformsLinkNodeToOembedNode = require("./tranformsLinkNodeToOembedNode");
 const logResults = require("./logResults");
+const getProxyAgent = require("./getProxyAgent");
 
 exports.amendOptions = amendOptions;
 exports.fetchOembedProviders = fetchOembedProviders;
@@ -19,3 +20,4 @@ exports.fetchOembed = fetchOembed;
 exports.selectPossibleOembedLinkNodes = selectPossibleOembedLinkNodes;
 exports.tranformsLinkNodeToOembedNode = tranformsLinkNodeToOembedNode;
 exports.logResults = logResults;
+exports.getProxyAgent = getProxyAgent;


### PR DESCRIPTION
### Why
Right now for some network issues, I couldn't use this plugin to fetch oembed code that providers return directly. This is a very common issue for many Chinese users and it caused by the [GFW](https://en.wikipedia.org/wiki/Great_Firewall).
To solve this, I have to hard code the configuration in **fetchOembed.js**  so that the **axios** could use socks5 proxy to request the data successfully.  Otherwise, I would get **ETIMEDOUT** errors. 

original:
```javascript
// node_modules/@raae/gatsby-remark-oembed/utils/fetchOembed.js
const axios = require("axios");

const fetchOembed = async endpoint => {
  const response = await axios.get(endpoint.url, {
    params: {
      format: "json",
      ...endpoint.params
    }
  });
  return response.data;
};

module.exports = fetchOembed;

```

My workaround: 
```javascript
// modified: node_modules/@raae/gatsby-remark-oembed/utils/fetchOembed.js
const axios = require("axios");
const SocksProxyAgent = require("socks-proxy-agent");

const fetchOembed = async endpoint => {
  const proxyHost = "127.0.0.1", proxyPort = "9999";
  const proxyOptions = `socks5://${proxyHost}:${proxyPort}`;
  const httpAgent = new SocksProxyAgent(proxyOptions);
  const httpsAgent = httpAgent;
  const response = await axios.get(endpoint.url, {
    params: {
      format: "json",
      ...endpoint.params
    },
    httpAgent: httpAgent,
    httpsAgent: httpsAgent
  });
  return response.data
```

However, these changes will be overwritten whenever yarn updates.

### Solution
The right way to solve this is by forking the repository to customized `gatsby-remark-oembed`.   I add a new option named `useProxy`  to custom the proxy that axios uses.

So I could use it like using `usePrefix`.

```javascript
 options:{
 useProxy: {
       host: '127.0.0.1',
        port: '1234',
        // useSocks5 defaults to true
         useSocks5: false // this will use  axios proxy config instead of socks5
       }
}
```
If useProxy is missing, the proxy is disabled as expected.
```javascript
 options:{
 useProxy:  false, // -> disable explicitly
}
```

### Files and test

I've modified `amendedOptions.js` and created a file named `getProxyAgent.js` to handle above processing. 
In order to maintain the stability of the plugin, I also created `getProxyAgent.test.js` and all tests were passed. In addition, some test cases were also added to other `.test.js` files.

### code review is needed 

I don't know whether some of my code is necessary to achieve this feature. 

