### PR TITLE
Move instagram error handling to link level

### DIFF
--- a/gatsby-remark-oembed/index.js
+++ b/gatsby-remark-oembed/index.js
@@ -34,6 +34,7 @@ module.exports = async (
 const processNode = async (node, providers) => {
   try {
     const endpoint = getProviderEndpointForLinkUrl(node.url, providers);
+
     if (endpoint.url) {
       const oembedResponse = await fetchOembed(endpoint);
       return tranformsLinkNodeToOembedNode(node, oembedResponse);

--- a/gatsby-remark-oembed/utils/.test/providers.js
+++ b/gatsby-remark-oembed/utils/.test/providers.js
@@ -2,6 +2,9 @@ module.exports = [
   {
     provider_name: "Instagram",
     provider_url: "https://instagram.com",
+    params: {
+      access_token: "valid_token"
+    },
     endpoints: [
       {
         schemes: [

--- a/gatsby-remark-oembed/utils/amendProviders.js
+++ b/gatsby-remark-oembed/utils/amendProviders.js
@@ -31,22 +31,6 @@ const amendProvider = (provider, settings = {}, providerKey) => {
 
 const amendProviders = (providers = [], settings = {}) => {
   const amendedProviders = providers.map(provider => {
-    if (provider.provider_name === "Instagram") {
-      if (!settings.Instagram) {
-        throw new Error(
-          "it seems you tried using `Instagram` provider but didn't pass any settings for it"
-        );
-      }
-
-      const { access_token } = settings.Instagram;
-
-      if (typeof access_token === "undefined" || access_token === "") {
-        throw new Error(
-          "it seems that you tried using the `Instagram` provider but didn't pass an access_token to the settings"
-        );
-      }
-    }
-
     return amendProvider(provider, settings[provider.provider_name]);
   });
 

--- a/gatsby-remark-oembed/utils/amendProviders.test.js
+++ b/gatsby-remark-oembed/utils/amendProviders.test.js
@@ -8,8 +8,7 @@ describe("#amendProviders", () => {
     },
     Instagram: {
       hidecaption: true,
-      omitscript: true,
-      access_token: "this_should_be_a_valid_token"
+      omitscript: true
     },
     Test1: {
       param1: "param1",
@@ -71,12 +70,6 @@ describe("#amendProviders", () => {
     expect(amendedInstagram.params).toEqual(providerSettings["Instagram"]);
   });
 
-  test("amended Instagram should have a valid access_token", () => {
-    expect(amendedInstagram.params.access_token).toEqual(
-      providerSettings.Instagram.access_token
-    );
-  });
-
   test("amended Vimeo has correct format", () => {
     expect(amendedVimeo.endpoints[0].url).toEqual(
       "https://vimeo.com/api/oembed.json"
@@ -101,25 +94,6 @@ describe("#amendProviders", () => {
       "https://test3.com/*"
     );
     expect(untouchedTest3.endpoints[0].url).toEqual("https://test3.com/oembed");
-  });
-
-  test("amend providers with no providerSettings for Instagram should throw an error", () => {
-    expect(() => amendProviders(PROVIDERS)).toThrowError(
-      "it seems you tried using `Instagram` provider but didn't pass any settings for it"
-    );
-  });
-
-  test("amend providers with no access_token for Instagram should throw an error", () => {
-    const providerSettings = {
-      Instagram: {
-        hidecaption: true,
-        omitscript: true
-      }
-    };
-
-    expect(() => amendProviders(PROVIDERS, providerSettings)).toThrowError(
-      "it seems that you tried using the `Instagram` provider but didn't pass an access_token"
-    );
   });
 
   test("Empty providers and/or settings is accepted", () => {

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
@@ -7,6 +7,14 @@ const getProviderEndpointForLinkUrl = (linkUrl, providers) => {
         schema = schema.replace("*", ".*");
         const regExp = new RegExp(schema);
         if (regExp.test(linkUrl)) {
+          if (provider.provider_name === "Instagram") {
+            if (!provider.params || !provider.params.access_token) {
+              throw new Error(
+                "Instagram require you to configure an access_token, check docs."
+              );
+            }
+          }
+
           transformedEndpoint.url = endpoint.url;
           transformedEndpoint.params = {
             url: linkUrl,

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
@@ -3,18 +3,19 @@ const getProviderEndpointForLinkUrl = (linkUrl, providers) => {
 
   for (const provider of providers || []) {
     for (const endpoint of provider.endpoints || []) {
+      const isInstagram = provider.provider_name === "Instagram";
+      const hasAccessToken = provider.params && provider.params.access_token;
+
       for (let schema of endpoint.schemes || []) {
         schema = schema.replace("*", ".*");
         const regExp = new RegExp(schema);
-        if (regExp.test(linkUrl)) {
-          if (provider.provider_name === "Instagram") {
-            if (!provider.params || !provider.params.access_token) {
-              throw new Error(
-                "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
-              );
-            }
-          }
+        const isMatchingSchema = regExp.test(linkUrl);
 
+        if (isMatchingSchema && isInstagram && !hasAccessToken) {
+          throw new Error(
+            "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
+          );
+        } else if (isMatchingSchema) {
           transformedEndpoint.url = endpoint.url;
           transformedEndpoint.params = {
             url: linkUrl,

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.js
@@ -10,7 +10,7 @@ const getProviderEndpointForLinkUrl = (linkUrl, providers) => {
           if (provider.provider_name === "Instagram") {
             if (!provider.params || !provider.params.access_token) {
               throw new Error(
-                "Instagram require you to configure an access_token, check docs."
+                "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
               );
             }
           }

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
@@ -16,7 +16,10 @@ describe("#getProviderEndpointForLinkUrl", () => {
       )
     ).toEqual({
       url: "https://api.instagram.com/oembed",
-      params: { url: "https://www.instagram.com/p/BftIg_OFPFX/" }
+      params: {
+        url: "https://www.instagram.com/p/BftIg_OFPFX/",
+        access_token: "valid_token"
+      }
     });
 
     expect(
@@ -25,6 +28,39 @@ describe("#getProviderEndpointForLinkUrl", () => {
         []
       )
     ).toEqual({});
+  });
+
+  test("throw error when Instagram does not have access_token", () => {
+    const NO_INSTA_TOKEN_PROVIDERS = [
+      {
+        provider_name: "Instagram",
+        provider_url: "https://instagram.com",
+        endpoints: [
+          {
+            schemes: [
+              "http://instagram.com/p/*",
+              "http://instagr.am/p/*",
+              "http://www.instagram.com/p/*",
+              "http://www.instagr.am/p/*",
+              "https://instagram.com/p/*",
+              "https://instagr.am/p/*",
+              "https://www.instagram.com/p/*",
+              "https://www.instagr.am/p/*"
+            ],
+            url: "https://api.instagram.com/oembed",
+            formats: ["json"]
+          }
+        ]
+      }
+    ];
+    expect(() =>
+      getProviderEndpointForLinkUrl(
+        "https://www.instagram.com/p/BftIg_OFPFX/",
+        NO_INSTA_TOKEN_PROVIDERS
+      )
+    ).toThrowError(
+      "Instagram require you to configure an access_token, check docs."
+    );
   });
 
   test("Empty providers and/or link: is accepted", () => {

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
@@ -30,28 +30,40 @@ describe("#getProviderEndpointForLinkUrl", () => {
     ).toEqual({});
   });
 
-  test("throw error when Instagram does not have access_token", () => {
+  describe("Instagram special need for an access token", () => {
     const NO_INSTA_TOKEN_PROVIDERS = [
       {
         provider_name: "Instagram",
         provider_url: "https://instagram.com",
         endpoints: [
           {
-            schemes: ["http://instagram.com/p/*"],
+            schemes: ["https://www.instagram.com/p/*"],
             url: "https://api.instagram.com/oembed",
             formats: ["json"]
           }
         ]
       }
     ];
-    expect(() =>
-      getProviderEndpointForLinkUrl(
-        "https://www.instagram.com/p/BftIg_OFPFX/",
-        NO_INSTA_TOKEN_PROVIDERS
-      )
-    ).toThrowError(
-      "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
-    );
+
+    test("throw error when Instagram link and no access_token", () => {
+      expect(() =>
+        getProviderEndpointForLinkUrl(
+          "https://www.instagram.com/p/BftIg_OFPFX/",
+          NO_INSTA_TOKEN_PROVIDERS
+        )
+      ).toThrowError(
+        "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
+      );
+    });
+
+    test("do not throw error when no Instagram link and no access_token", () => {
+      expect(
+        getProviderEndpointForLinkUrl(
+          "https://www.example.com/post",
+          NO_INSTA_TOKEN_PROVIDERS
+        )
+      ).toEqual({});
+    });
   });
 
   test("Empty providers and/or link: is accepted", () => {

--- a/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
+++ b/gatsby-remark-oembed/utils/getProviderEndpointForLinkUrl.test.js
@@ -37,16 +37,7 @@ describe("#getProviderEndpointForLinkUrl", () => {
         provider_url: "https://instagram.com",
         endpoints: [
           {
-            schemes: [
-              "http://instagram.com/p/*",
-              "http://instagr.am/p/*",
-              "http://www.instagram.com/p/*",
-              "http://www.instagr.am/p/*",
-              "https://instagram.com/p/*",
-              "https://instagr.am/p/*",
-              "https://www.instagram.com/p/*",
-              "https://www.instagr.am/p/*"
-            ],
+            schemes: ["http://instagram.com/p/*"],
             url: "https://api.instagram.com/oembed",
             formats: ["json"]
           }
@@ -59,7 +50,7 @@ describe("#getProviderEndpointForLinkUrl", () => {
         NO_INSTA_TOKEN_PROVIDERS
       )
     ).toThrowError(
-      "Instagram require you to configure an access_token, check docs."
+      "Instagram require you to configure an access_token. For more information, visit https://developers.facebook.com/docs/instagram/oembed/."
     );
   });
 

--- a/gatsby-remark-oembed/utils/logResults.js
+++ b/gatsby-remark-oembed/utils/logResults.js
@@ -8,8 +8,7 @@ const logResults = (results, node, reporter) => {
     if (result instanceof Error) {
       failedEmbedsCount++;
       reporter.error(
-        `gatsby-remark-oembed: Error embedding ${result.url}`,
-        result
+        `gatsby-remark-oembed: Error embedding ${result.url} - ${result.message}`
       );
     } else if (result) {
       successfulEmbedsCount++;

--- a/gatsby-remark-oembed/utils/logResults.test.js
+++ b/gatsby-remark-oembed/utils/logResults.test.js
@@ -34,6 +34,6 @@ describe("#logResults", () => {
 
   test("Calls reporter.error correctly", () => {
     expect(reporter1.error.mock.calls.length).toBe(1);
-    expect(reporter1.error.mock.calls[0][1]).toEqual(new Error("Test Error"));
+    expect(reporter1.error.mock.calls[0][0]).toContain("Test Error");
   });
 });


### PR DESCRIPTION
##  Description

The core design of the plugin is that its very forgiving. If something cannot be embedded we display the link as it. It should not stop the build if there are errors with individual embed links.

## Related issues
- Closes #131

## Fun

![Cat having fun with Instagram](https://media.giphy.com/media/2tSodgDfwCjIMCBY8h/source.gif)